### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
My local repo has NodeJS-related code. Without `.gitignore`, I'm going to probably accidentally commit an entire `node_modules` directory. Hopefully this keeps that from happening.